### PR TITLE
Use Esprima 2.x.

### DIFF
--- a/config.js
+++ b/config.js
@@ -43,6 +43,7 @@ module.exports = {
     , 'do'          :  undefined
 
     , 'else'        :  undefined
+    , 'enum'        :  undefined
     , 'export'      :  undefined
     , 'extends'     :  undefined
 
@@ -51,11 +52,19 @@ module.exports = {
     , 'function'    :  undefined
 
     , 'if'          :  undefined
+    , 'implements'  :  undefined
     , 'import'      :  undefined
     , 'in'          :  undefined
     , 'instanceof'  :  undefined
+    , 'interface'   :  undefined
     , 'let'         :  undefined
     , 'new'         :  undefined
+
+    , 'package'     :  undefined
+    , 'private'     :  undefined
+    , 'protected'   :  undefined
+    , 'public'      :  undefined
+
     , 'return'      :  undefined
     , 'static'      :  undefined
     , 'super'       :  undefined

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -27,7 +27,7 @@
 
 
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
-    <script type="text/javascript" src="https://rawgit.com/RReverser/esprima-fb/fb-harmony/esprima.js"></script>
+    <script type="text/javascript" src="http://esprima.org/esprima.js"></script>
     <script type="text/javascript" src="../../redeyed.js"></script>
     <script type="text/javascript" src="./sample-config.js"></script>
     <script type="text/javascript" src="./index.js"></script>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "cardinal": "~0.4.4"
   },
   "dependencies": {
-    "esprima-fb": "~12001.1.0-dev-harmony-fb"
+    "esprima": "~2.7.0"
   }
 }

--- a/redeyed.js
+++ b/redeyed.js
@@ -11,13 +11,13 @@ var esprima
 
 if (typeof module === 'object' && typeof module.exports === 'object' && typeof require === 'function') {
   // server side
-  esprima = require('esprima-fb');
+  esprima = require('esprima');
   exportFn = function (redeyed) { module.exports = redeyed; };
   bootstrap(esprima, exportFn);
 } else if (typeof define === 'function' && define.amd) {
   // client side
   // amd
-  define(['esprima-fb'], function (esprima) {
+  define(['esprima'], function (esprima) {
       return bootstrap(esprima);
   });
 } else if (typeof window === 'object') {

--- a/test/redeyed-browser.js
+++ b/test/redeyed-browser.js
@@ -6,7 +6,7 @@ var test = require('tap').test
   , util = require('util')
   , redeyedExport = require('..')
   , redeyedkey = require.resolve('..')
-  , esprima = require('esprima-fb')
+  , esprima = require('esprima')
 
 function setup() {
   // remove redeyed from require cache to force re-require for each test

--- a/test/redeyed-result.js
+++ b/test/redeyed-result.js
@@ -4,7 +4,7 @@
 var test = require('tap').test
   , util = require('util')
   , redeyed = require('..')
-  , esprima = require('esprima-fb')
+  , esprima = require('esprima')
 
 function inspect (obj) {
   return util.inspect(obj, false, 5, true)

--- a/test/redeyed-smoke.js
+++ b/test/redeyed-smoke.js
@@ -9,7 +9,7 @@ var test     =  require('tap').test
   , redeyed  =  require('..')
   , node_modules =  path.join(__dirname, '..', 'node_modules')
   , tapdir       =  path.join(node_modules, 'tap')
-  , esprimadir   =  path.join(node_modules, 'esprima-fb')
+  , esprimadir   =  path.join(node_modules, 'esprima')
 
 test('tap', function (t) {
   var invalidTapFiles = [


### PR DESCRIPTION
Facebook's fork is deprecated. Let's just the mainline Esprima 2.x since it already supports major ES6 features.