### PR TITLE
Fix a potentially failing smoke test

### DIFF
--- a/test/redeyed-smoke.js
+++ b/test/redeyed-smoke.js
@@ -15,6 +15,7 @@ test('tap', function (t) {
   var invalidTapFiles = [
       'async-map-ordered.js'
     , 'prof.js'
+    , 'whitespace.js'
   ]
 
   readdirp({ root: tapdir, fileFilter: '*.js' })


### PR DESCRIPTION
Exclude `whitespace.js` from the smoke test since it contains U+180E
which is not a whitespace anymore in the upcoming ES2016.
That `whitespace.js` is part of UglifyJS tests, included from the
following module dependency:

└─┬ tap@0.4.13
  ├─┬ runforcover@0.0.2
  │ └─┬ bunker@0.1.2
  │   └─┬ burrito@0.2.12
  │     ├── traverse@0.5.2
  │     └── uglify-js@1.1.1