### PR TITLE
Use Espree instead of esprima to support newer ES specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "cardinal": "~0.4.4"
   },
   "dependencies": {
-    "esprima": "~2.7.0"
+    "espree": "^3.1.7"
   }
 }

--- a/redeyed.js
+++ b/redeyed.js
@@ -214,9 +214,6 @@ function bootstrap(esprima, exportFn) {
             // enable return in global scope
             globalReturn: true,
 
-            // enable implied strict mode (if ecmaVersion >= 5)
-            impliedStrict: true,
-
             // allow experimental object rest/spread
             experimentalObjectRestSpread: true
           }

--- a/test/redeyed-browser.js
+++ b/test/redeyed-browser.js
@@ -6,7 +6,7 @@ var test = require('tap').test
   , util = require('util')
   , redeyedExport = require('..')
   , redeyedkey = require.resolve('..')
-  , esprima = require('esprima')
+  , esprima = require('espree')
 
 function setup() {
   // remove redeyed from require cache to force re-require for each test

--- a/test/redeyed-result.js
+++ b/test/redeyed-result.js
@@ -4,7 +4,7 @@
 var test = require('tap').test
   , util = require('util')
   , redeyed = require('..')
-  , esprima = require('esprima')
+  , esprima = require('espree')
 
 function inspect (obj) {
   return util.inspect(obj, false, 5, true)

--- a/test/redeyed-smoke.js
+++ b/test/redeyed-smoke.js
@@ -34,7 +34,7 @@ test('tap', function (t) {
     , 'lodash/utility/'
   ]
 
-  readdirp({ root: tapdir, fileFilter: '*.js' })
+  readdirp({ root: tapdir, fileFilter: '*.js', directoryFilter: '!node_modules' })
     .on('data', function (entry) {
 
       if (!shouldProcess(entry.fullPath, invalidTapFiles)) {
@@ -51,10 +51,10 @@ test('tap', function (t) {
 
 test('esprima', function (t) {
 
-  readdirp({ root: esprimadir, fileFilter: '*.js' })
+  readdirp({ root: esprimadir, fileFilter: '*.js', directoryFilter: '!node_modules' })
     .on('data', function (entry) {
       var invalidEspreeFiles = [
-          'lib/visitor-keys.js'
+          'espree/lib/visitor-keys.js'
       ]
 
       if (!shouldProcess(entry.fullPath, invalidEspreeFiles)) {

--- a/test/redeyed-smoke.js
+++ b/test/redeyed-smoke.js
@@ -9,7 +9,17 @@ var test     =  require('tap').test
   , redeyed  =  require('..')
   , node_modules =  path.join(__dirname, '..', 'node_modules')
   , tapdir       =  path.join(node_modules, 'tap')
-  , esprimadir   =  path.join(node_modules, 'esprima')
+  , esprimadir   =  path.join(node_modules, 'espree')
+
+function shouldProcess (path, blacklist) {
+    var include = true
+
+    blacklist.every(function (entry) {
+        return include = (path.indexOf(entry) < 0)
+    });
+
+    return include
+}
 
 test('tap', function (t) {
   var invalidTapFiles = [
@@ -24,20 +34,10 @@ test('tap', function (t) {
     , 'lodash/utility/'
   ]
 
-  function shouldProcess (path) {
-      var include = true
-
-      invalidTapFiles.every(function (entry) {
-          return include =  (path.indexOf(entry) < 0)
-      });
-
-      return include
-  }
-
   readdirp({ root: tapdir, fileFilter: '*.js' })
     .on('data', function (entry) {
 
-      if (!shouldProcess(entry.fullPath)) {
+      if (!shouldProcess(entry.fullPath, invalidTapFiles)) {
           return
       }
 
@@ -53,6 +53,13 @@ test('esprima', function (t) {
 
   readdirp({ root: esprimadir, fileFilter: '*.js' })
     .on('data', function (entry) {
+      var invalidEspreeFiles = [
+          'lib/visitor-keys.js'
+      ]
+
+      if (!shouldProcess(entry.fullPath, invalidEspreeFiles)) {
+          return
+      }
       
       var code = fs.readFileSync(entry.fullPath, 'utf-8')
         , result = redeyed(code, { Keyword: { 'var': '+:-' } }).code


### PR DESCRIPTION
All tests still pass and I verified that it works by npm linking this branch to a local version of cardinal, which I then linked to a project where I successfully highlighted code that use the stage 2 proposal for object spread syntax.

Fixes thlorenz/cardinal#16