### PR TITLE
Travis CI: ignore legacy Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
   - "6"
 before_install:
   - npm install -g npm@2


### PR DESCRIPTION
Reasons:

* v0.10: LTS will end soon, on 2016-10-01
* v0.12: LTS ended on 2016-04-01, unmaintained from 2016-12-31
* v5: unmaintained, https://nodejs.org/en/blog/community/v5-to-v7/