### PR TITLE
Update jquery url in example

### DIFF
--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -26,7 +26,7 @@
     </section>
 
 
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.0/jquery.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/esprima"></script>
     <script type="text/javascript" src="../../redeyed.js"></script>
     <script type="text/javascript" src="./sample-config.js"></script>


### PR DESCRIPTION
Hi, I totally understand that it's not a security issue for using this library as a dependency.

But some scanning tools (like WhiteSource Bolt mentioned at #22) can consider the whole library as vulnerable due to the outdated jquery version. Even more important point is examples can be used as guidance for implementing redeyed (as a dependency). So I assume it's good practice to keep <script> URLs in examples as secure as possible.